### PR TITLE
sipt: Add functions to work with forwarding info

### DIFF
--- a/src/modules/sipt/doc/sipt_admin.xml
+++ b/src/modules/sipt/doc/sipt_admin.xml
@@ -93,6 +93,22 @@ sipt_set_calling($fU, 4, 0, 3);
 </programlisting>
 		</example>
 	</section>
+	<section id="sipt.f.sipt_forwarding">
+		<title><function moreinfo="none">sipt_forwarding(origin, nai)</function></title>
+		<para>
+			updates the IAM in the body if it exists, setting (or adding) the forwarding number to <quote>origin</quote>
+			with the nature address specified in <quote>nai</quote>.
+		</para>
+		<example>
+			<title><function moreinfo="none">sipt_set_calling(origin, nai)</function> usage</title>
+			<programlisting format="linespecific">
+...
+# update the forwarding number to the value in the from header
+sipt_forwarfing($avp(s:forwarding_number), 3);
+...
+</programlisting>
+		</example>
+	</section>
 </section>
 <section>
         <title>Exported pseudo-variables</title>
@@ -313,7 +329,63 @@ if($sipt(called_party_number.nai) == 3)
 			</tgroup>
 		</table>
 	</section>
+	<section id="sipt.v.sipt_redirection_info">
+		<title><varname>$sipt_redirection_info</varname></title>
+		<para>
+			Returns redirection info header from ISUP
+			Returns "Redirecting reason" or -1 if no redirection info found.
+		</para>
+		<table>
+			<title>Redirecting reason Values</title>
+			<tgroup cols="2">
+				<tbody>
+					<row><entry>0</entry><entry>Unknown</entry></row>
+					<row><entry>1</entry><entry>User busy</entry></row>
+					<row><entry>2</entry><entry>PROGRESS</entry></row>
+					<row><entry>3</entry><entry>no reply</entry></row>
+					<row><entry>4</entry><entry>deflection during alerting</entry></row>
+					<row><entry>5</entry><entry>deflection immediate response</entry></row>
+					<row><entry>6</entry><entry>mobile subscriber not reachable</entry></row>
+				</tbody>
+			</tgroup>
+		</table>
+	</section>
+        	<section id="sipt.v.sipt_redirection_number">
+		<title><varname>$sipt_redirection_number</varname></title>
+		<para>
+			Returns number to which redirection will trigered
+			Returns -1 if there is a parsing error.
+		</para>
+		<example>
+			<title><function moreinfo="none">sipt_redirection_number</function> usage</title>
+			<programlisting format="linespecific">
+...
+# get the redirection number
+$avp(s:redir_num) = $sipt_redirection_number+"";
 
+...
+</programlisting>
+		</example>
+	</section>
+	<section id="sipt.v.sipt_redirection_number_nai">
+		<title><varname>$sipt_redirection_number_nai</varname></title>
+		<para>
+			Returns NAI for redirection number from ISUP
+			Returns NAI for redirection number or -1 if no info found.
+		</para>
+		<table>
+			<title>Redirecting number NAI Values</title>
+			<tgroup cols="2">
+				<tbody>
+					<row><entry>0</entry><entry>Spare</entry></row>
+					<row><entry>1</entry><entry>Subscriber Number (national use)</entry></row>
+					<row><entry>2</entry><entry>Unknown (national use)</entry></row>
+					<row><entry>3</entry><entry>National (significant) number (national use)</entry></row>
+					<row><entry>4</entry><entry>International use</entry></row>
+				</tbody>
+			</tgroup>
+		</table>
+	</section>
 </section>
 </chapter>
 

--- a/src/modules/sipt/ss7.h
+++ b/src/modules/sipt/ss7.h
@@ -177,14 +177,12 @@ struct isup_iam_fixed {
 struct isup_acm_fixed {
 	unsigned char type;
 	unsigned char backwards_call_ind[2];
-	unsigned char fixed_pointer;
 	unsigned char optional_pointer;
 };
 
 struct isup_cpg_fixed {
 	unsigned char type;
 	unsigned char event_info;
-	unsigned char fixed_pointer;
 	unsigned char optional_pointer;
 };
 
@@ -206,6 +204,10 @@ int isup_get_charging_indicator(unsigned char *buf, int len);
 int isup_update_destination(struct sdp_mangler * mangle, char * dest, int hops, int nai, unsigned char *buf, int len);
 int isup_update_bci_1(struct sdp_mangler * mangle, int charge_indicator, int called_status, int called_category, int e2e_indicator, unsigned char *buf, int len);
 int isup_update_calling(struct sdp_mangler * mangle, char * origin, int nai, int presentation, int screening, unsigned char * buf, int len);
+int isup_update_forwarding(struct sdp_mangler * mangle, char * forwardn, int nai, unsigned char *buf, int len);
 
+int isup_get_redirection_info(unsigned char *buf, int len);
+int isup_get_redirection_number_nai(unsigned char *buf, int len);
+int isup_get_redirection_number(unsigned char *buf, int len, unsigned char *sb_buf, int sb_len);
 
 #endif

--- a/src/modules/sipt/ss7_parser.c
+++ b/src/modules/sipt/ss7_parser.c
@@ -143,6 +143,19 @@ static int encode_calling_party(char * number, int nai, int presentation, int sc
         return datalen + 2;
 }
 
+static int encode_forwarding_number(char * number, int nai, unsigned char * buf, int len) 
+{
+        int oddeven, datalen;
+
+        isup_put_number(&buf[2], number, &datalen, &oddeven);
+
+        buf[0] = (oddeven << 7) | nai;      /* Nature of Address Indicator */
+         /* Assume E.164 ISDN numbering plan, calling number complete */
+        buf[1] = 0x14;
+
+        return datalen + 2;
+}
+
 // returns start of specified optional header of IAM or CPG, otherwise return -1
 static int get_optional_header(unsigned char header, unsigned char *buf, int len)
 {
@@ -320,6 +333,67 @@ int isup_get_charging_indicator(unsigned char *buf, int len) {
 		return -1;
 
 	return (orig_message->backwards_call_ind[0] & 0x03);
+}
+
+int isup_get_redirection_info(unsigned char *buf, int len)
+{
+       int  offset = get_optional_header(ISUP_PARM_GENERIC_NOTIFICATION_IND, buf, len);
+
+       int call_is_diverting = 0;
+       int diversion_reason = 0;
+
+       if(offset != -1 && len-offset > 1)
+       {
+               call_is_diverting = (buf[offset+2]) & 0x7F;
+
+               if ( call_is_diverting == 123 ) {
+                       int  offset1 = get_optional_header(ISUP_PARM_DIVERSION_INFORMATION, buf, len);
+
+                       if(offset1 != -1 && len-offset1 > 1)
+                       {
+                               diversion_reason = (buf[offset1+2]>>3 & 0x0F);
+                               return diversion_reason;
+                       }
+               }
+               return -1;
+
+       }
+        return -1;
+}
+
+int isup_get_redirection_number_nai(unsigned char *buf, int len)
+{
+       int  offset = get_optional_header(ISUP_PARM_REDIRECTION_NUMBER, buf, len);
+
+       if(offset != -1 && len-offset-2 > 1)
+       {
+               return buf[offset+2] & 0x7F;
+       }
+       return -1;
+}
+
+int isup_get_redirection_number(unsigned char *buf, int len, unsigned char *sb_buf, int sb_len)
+{
+       int sbparamlen;
+       int sb_i=0;
+       int sb_j=0;
+       int  offset = get_optional_header(ISUP_PARM_REDIRECTION_NUMBER, buf, len);
+
+       if(offset != -1 && len-offset-2 > 1)
+       {
+               sbparamlen = (buf[offset+1] & 0xFF) - 2;
+
+               while ((sbparamlen > 0) && (buf[offset] != 0)) {
+                   sb_buf[sb_i]=(buf[offset+4+sb_j] & 0x0F) + '\x30';
+                   sb_buf[sb_i+1]=(buf[offset+4+sb_j]>>4 & 0x0F) + '\x30';
+                   sb_i=sb_i+2;
+                   sbparamlen--;
+                   sb_j++;
+               }
+               sb_buf[sb_i] = '\x0';
+               return sb_i;
+       }
+       return -1;
 }
 
 int isup_update_bci_1(struct sdp_mangler * mangle, int charge_indicator, int called_status, int called_category, int e2e_indicator, unsigned char *buf, int len)
@@ -514,6 +588,70 @@ int isup_update_calling(struct sdp_mangler * mangle, char * origin, int nai, int
 			new_party[1] = (char)res;
 
 			add_body_segment(mangle, offset,new_party, res+2);
+		}
+
+	}
+
+	return offset;
+}
+
+int isup_update_forwarding(struct sdp_mangler * mangle, char * forwardn, int nai, unsigned char *buf, int len)
+{
+	int offset = 0;
+	int res;
+	struct isup_iam_fixed * orig_message = (struct isup_iam_fixed*)buf;
+
+	// not an iam? do nothing
+	if(orig_message->type != ISUP_IAM)
+	{
+		return 1;
+	}
+
+	/* Copy the fixed parms */
+	len -= offsetof(struct isup_iam_fixed, called_party_number);
+	offset += offsetof(struct isup_iam_fixed, called_party_number);
+
+	if (len < 1)
+		return -1;
+
+
+	/* IAM has one Fixed variable param, Called party number, we need to modify this */
+
+
+	// add the new mandatory fixed header
+	res = buf[offset];
+	offset += res+1;
+	len -= res+1;
+	
+	if (len < 1 )
+		return -1;
+
+	/* Optional paramter parsing code */
+	if (orig_message->optional_pointer) {
+	
+		while ((len > 0) && (buf[offset] != 0)) {
+			int res2 = 0;
+			struct isup_parm_opt *optparm = (struct isup_parm_opt *)(buf + offset);
+			unsigned char new_party[255];
+
+			res = optparm->len+2;
+			switch(optparm->type)
+			{
+				case ISUP_PARM_REDIRECTING_NUMBER:
+					res2 = encode_forwarding_number(forwardn, nai, &new_party[1], 255-1);
+					new_party[0] = (char)res2;
+					replace_body_segment(mangle, offset+1,(int)buf[offset+1]+1,new_party, res2+1);
+					break;
+                                case ISUP_PARM_ORIGINAL_CALLED_NUM:
+					res2 = encode_forwarding_number(forwardn, nai, &new_party[1], 255-1);
+					new_party[0] = (char)res2;
+					replace_body_segment(mangle, offset+1,(int)buf[offset+1]+1,new_party, res2+1);
+				default:
+					break;
+			}
+
+			len -= res;
+			offset += res;
 		}
 
 	}


### PR DESCRIPTION
<!-- Kamailio Pull Request Template -->

<!--
IMPORTANT:
  - for detailed contributing guidelines, read:
    https://github.com/kamailio/kamailio/blob/master/.github/CONTRIBUTING.md
  - pull requests must be done to master branch, unless they are backports
    of fixes from master branch to a stable branch
  - backports to stable branches must be done with 'git cherry-pick -x ...'
  - code is contributed under BSD for core and main components (tm, sl, auth, tls)
  - code is contributed GPLv2 or a compatible license for the other components
  - GPL code is contributed with OpenSSL licensing exception
-->
#### Type Of Change
- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply -->
- [ ] PR should be backported to stable branches
- [x] Tested changes locally
- [ ] Related to issue #XXXX (replace XXXX with an open issue number)

#### Description
<!-- Describe your changes in detail -->

This commits adding some new functions to Get and Change forwarding info in ISUP part of SIP-I/SIP-T messages.

sipt_forwarding(origin, nai) - updates the IAM in the body if it exists, setting (or adding) the forwarding number to origin with the nature address specified in nai

$sipt_redirection_info - Returns "Redirecting reason" or -1 if no redirection info found.

$sipt_redirection_number - Returns number to which redirection will trigered

sipt_redirection_number_nai - Returns NAI for redirection number from ISUP